### PR TITLE
SHA1 hashes are publicly exposed in the cache dir

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "license": "LGPL-3.0-only",
     "require": {
         "guzzlehttp/guzzle": "^6.3",
-        "rapidwebltd/rw-file-cache-psr-6": "^1.0"
+        "kevinrob/guzzle-cache-middleware": "^3.2",
+        "doctrine/cache": "^1.7"
     }
 }

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -10,7 +10,6 @@ use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Kevinrob\GuzzleCache\Storage\DoctrineCacheStorage;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
-use rapidweb\RWFileCachePSR6\CacheItemPool;
 
 class PasswordExposedChecker
 {
@@ -24,7 +23,7 @@ class PasswordExposedChecker
             new CacheMiddleware(
                 new PrivateCacheStrategy(
                     new DoctrineCacheStorage(
-                        new FilesystemCache(sys_get_temp_dir() . '/pwned-passwords-cache')
+                        new FilesystemCache(sys_get_temp_dir().'/pwned-passwords-cache')
                     )
                 )
             ),

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -2,28 +2,39 @@
 
 namespace DivineOmega\PasswordExposed;
 
+use Doctrine\Common\Cache\FilesystemCache;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Kevinrob\GuzzleCache\CacheMiddleware;
+use Kevinrob\GuzzleCache\Storage\DoctrineCacheStorage;
+use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
 use rapidweb\RWFileCachePSR6\CacheItemPool;
 
 class PasswordExposedChecker
 {
     private $client;
-    private $cache;
-
-    const CACHE_EXPIRY_SECONDS = 60 * 60 * 24 * 30;
 
     public function __construct()
     {
+        $stack = HandlerStack::create();
+
+        $stack->push(
+            new CacheMiddleware(
+                new PrivateCacheStrategy(
+                    new DoctrineCacheStorage(
+                        new FilesystemCache(sys_get_temp_dir() . '/pwned-passwords-cache')
+                    )
+                )
+            ),
+            'cache'
+        );
+
         $this->client = new Client([
+            'handler'  => $stack,
             'base_uri' => 'https://api.pwnedpasswords.com/',
             'timeout'  => 3.0,
-        ]);
-
-        $this->cache = new CacheItemPool();
-        $this->cache->changeConfig([
-            'cacheDirectory' => '/tmp/password-exposed-cache/',
         ]);
     }
 
@@ -32,25 +43,11 @@ class PasswordExposedChecker
         $hash = sha1($password);
         unset($password);
 
-        $cacheKey = substr($hash, 0, 2).'_'.substr($hash, 2);
-
-        $cacheItem = $this->cache->getItem($cacheKey);
-
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
-
         $status = PasswordStatus::UNKNOWN;
 
         try {
             $status = $this->getPasswordStatus($hash, $this->makeRequest($hash));
         } catch (ConnectException $e) {
-        }
-
-        if (in_array($status, [PasswordStatus::EXPOSED, PasswordStatus::NOT_EXPOSED])) {
-            $cacheItem->set($status);
-            $cacheItem->expiresAfter(self::CACHE_EXPIRY_SECONDS);
-            $this->cache->save($cacheItem);
         }
 
         return $status;


### PR DESCRIPTION
It's possible to recover the SHA1 of every password checked in the last 30 days by browsing the `/tmp/password-exposed-cache` folder.

Example
```php
<?php

require_once(__DIR__ . '/vendor/autoload.php');

const DEMO_PASSWORD = 'WdBNSvWGnovprIe92mn4w3oinmWFxkbTHffqf8S8dUhYmNnbNjLJnUS1M7N6gVZ';

$passwordStatus = password_exposed(DEMO_PASSWORD);

echo 'Using a demo password of ' . DEMO_PASSWORD . ' with SHA1 ' . sha1(DEMO_PASSWORD) . PHP_EOL;
echo 'Status is: ' . $passwordStatus;
```

Output:

> ➜  password_exposed git:(master) ✗ php play.php
> Using a demo password of WdBNSvWGnovprIe92mn4w3oinmWFxkbTHffqf8S8dUhYmNnbNjLJnUS1M7N6gVZ with SHA1 604c4b2521a23ccd21572619e84a895e4153d88a
> Status is: not_exposed
> 
> ➜  password_exposed git:(master) ✗ tree /tmp/password-exposed-cache
> /tmp/password-exposed-cache
> └── 60
>     └── 4c4b2521a23ccd21572619e84a895e4153d88a.cache
> 
> 1 directory, 1 file

PR changes to caching the API response instead.