### PR TITLE
Cache response body rather than exposed status

### DIFF
--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -32,28 +32,35 @@ class PasswordExposedChecker
         $hash = sha1($password);
         unset($password);
 
-        $cacheKey = substr($hash, 0, 2).'_'.substr($hash, 2);
+        $cacheKey = substr($hash, 0, 2).'_'.substr($hash, 2, 3);
 
         $cacheItem = $this->cache->getItem($cacheKey);
 
         if ($cacheItem->isHit()) {
-            return $cacheItem->get();
+
+            $responseBody = $cacheItem->get();
+
+        } else {
+
+            try {
+                $response = $this->makeRequest($hash);
+            } catch (ConnectException $e) {
+                return PasswordStatus::UNKNOWN;
+            }
+
+            if ($response->getStatusCode() !== 200) {
+                return PasswordStatus::UNKNOWN;
+            }
+
+            $responseBody = (string) $response->getBody();
+
         }
 
-        $status = PasswordStatus::UNKNOWN;
+        $cacheItem->set($responseBody);
+        $cacheItem->expiresAfter(self::CACHE_EXPIRY_SECONDS);
+        $this->cache->save($cacheItem);
 
-        try {
-            $status = $this->getPasswordStatus($hash, $this->makeRequest($hash));
-        } catch (ConnectException $e) {
-        }
-
-        if (in_array($status, [PasswordStatus::EXPOSED, PasswordStatus::NOT_EXPOSED])) {
-            $cacheItem->set($status);
-            $cacheItem->expiresAfter(self::CACHE_EXPIRY_SECONDS);
-            $this->cache->save($cacheItem);
-        }
-
-        return $status;
+        return $this->getPasswordStatus($hash, $responseBody);
     }
 
     private function makeRequest($hash)
@@ -68,18 +75,12 @@ class PasswordExposedChecker
         return $this->client->request('GET', 'range/'.substr($hash, 0, 5), $options);
     }
 
-    private function getPasswordStatus($hash, Response $response)
+    private function getPasswordStatus($hash, $responseBody)
     {
-        if ($response->getStatusCode() !== 200) {
-            return PasswordStatus::UNKNOWN;
-        }
-
         $hash = strtoupper($hash);
         $hashSuffix = substr($hash, 5);
 
-        $body = (string) $response->getBody();
-
-        $lines = explode("\r\n", $body);
+        $lines = explode("\r\n", $responseBody);
 
         foreach ($lines as $line) {
             list($exposedHashSuffix, $occurrences) = explode(':', $line);

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -4,7 +4,6 @@ namespace DivineOmega\PasswordExposed;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Psr7\Response;
 use rapidweb\RWFileCachePSR6\CacheItemPool;
 
 class PasswordExposedChecker


### PR DESCRIPTION
* Prevent full SHA1s being exposed in cache file names, by setting the cache key to the first 5 characters of the hash.
* Caching the response body, rather than the exposed status.

Thanks to @symm for the original idea. :)