### PR TITLE
Integrate with paragonie/certainty for validated SSL/TLS certificates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ install:
   - composer update
 script:
  - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
+ - ./vendor/bin/psalm
 after_script:
  - php vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7",
         "fzaninotto/faker": "^1.7",
-        "satooshi/php-coveralls": "^2.0"
+        "satooshi/php-coveralls": "^2.0",
+        "vimeo/psalm": "^1"
     },
     "autoload": {
         "psr-4": {
@@ -24,6 +25,7 @@
     "license": "LGPL-3.0-only",
     "require": {
         "guzzlehttp/guzzle": "^6.3",
+        "paragonie/certainty": "^1",
         "rapidwebltd/rw-file-cache-psr-6": "^1.0"
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+>
+    <projectFiles>
+        <directory name="src" />
+    </projectFiles>
+</psalm>

--- a/src/PasswordExposedFunction.php
+++ b/src/PasswordExposedFunction.php
@@ -3,6 +3,11 @@
 use DivineOmega\PasswordExposed\PasswordExposedChecker;
 
 if (!function_exists('password_exposed')) {
+    /**
+     * @param string $password
+     *
+     * @return string
+     */
     function password_exposed($password)
     {
         return (new PasswordExposedChecker())->passwordExposed($password);


### PR DESCRIPTION
This also makes the library's docblocks, etc. fully type-safe and uses Psalm to verify it.

Keep in mind that Certainty requires PHP 5.6 so this might be a no-go if you wanted e.g. PHP 5.4 compatibility.