### PR TITLE
Makes PasswordExposedChecker compatible with Windows

### DIFF
--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -36,7 +36,7 @@ class PasswordExposedChecker
         if (!$cache) {
             $cache = new CacheItemPool();
             $cache->changeConfig([
-                'cacheDirectory' => sys_get_temp_dir() . '/password-exposed-cache/',
+                'cacheDirectory' => sys_get_temp_dir().'/password-exposed-cache/',
             ]);
         }
         $this->cache = $cache;

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -36,7 +36,7 @@ class PasswordExposedChecker
         if (!$cache) {
             $cache = new CacheItemPool();
             $cache->changeConfig([
-                'cacheDirectory' => '/tmp/password-exposed-cache/',
+                'cacheDirectory' => sys_get_temp_dir() . '/password-exposed-cache/',
             ]);
         }
         $this->cache = $cache;


### PR DESCRIPTION
The directory `/tmp` doesn't exist on Windows, so the `CacheItemPool` used by the `PasswordExposedChecker` cannot be written.