### PR TITLE
Add method that does not make use of the real password

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ If you prefer to avoid using helper functions, the following syntax is also avai
 ```php
 $passwordStatus = (new PasswordExposedChecker())->passwordExposed($password);
 ```
+
+You can also supply the SHA1 hash instead of the plain text password, by using the following method.
+
+```php
+$passwordStatus = (new PasswordExposedChecker())->passwordExposedByHash($hash);
+```

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -81,9 +81,16 @@ class PasswordExposedChecker
      */
     public function passwordExposed($password)
     {
-        $hash = sha1($password);
-        unset($password);
+        return $this->passwordExposedByHash(sha1($password));
+    }
 
+    /**
+     * @param string $hash Hexadecimal SHA-1 hash of the password
+     *
+     * @return string (see PasswordStatus)
+     */
+    public function passwordExposedByHash($hash)
+    {
         $cacheKey = substr($hash, 0, 2).'_'.substr($hash, 2, 3);
 
         $cacheItem = $this->cache->getItem($cacheKey);

--- a/tests/Unit/PasswordExposedByHashTest.php
+++ b/tests/Unit/PasswordExposedByHashTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace DivineOmega\PasswordExposed\Tests;
+
+use DivineOmega\PasswordExposed\PasswordExposedChecker;
+use DivineOmega\PasswordExposed\PasswordStatus;
+use Faker\Factory;
+use PHPUnit\Framework\TestCase;
+
+class PasswordExposedByHashTest extends TestCase
+{
+    /** @var PasswordExposedChecker */
+    private $checker;
+
+    protected function setUp()
+    {
+        $this->checker = new PasswordExposedChecker();
+    }
+
+    /**
+     * @return array
+     */
+    public function exposedPasswordHashProvider()
+    {
+        return [
+            [sha1('test')],
+            [sha1('password')],
+            [sha1('hunter2')],
+        ];
+    }
+
+    /**
+     * @dataProvider exposedPasswordHashProvider
+     *
+     * @param string $hash
+     */
+    public function testExposedPasswords($hash)
+    {
+        $this->assertEquals($this->checker->passwordExposedByHash($hash), PasswordStatus::EXPOSED);
+    }
+
+    public function testNotExposedPasswords()
+    {
+        $this->assertEquals(
+            $this->checker->passwordExposedByHash($this->getPasswordHashUnlikelyToBeExposed()),
+            PasswordStatus::NOT_EXPOSED
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getPasswordHashUnlikelyToBeExposed()
+    {
+        $faker = Factory::create();
+
+        return sha1($faker->words(6, true));
+    }
+}


### PR DESCRIPTION
However unlikely, passing a real password to a library is a risk in itself. Since there is no need to do that in this case we should provide a method to check a password by it's SHA-1 hash.