### PR TITLE
Allow custom PSR 6 cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "php": ">=5.6",
         "guzzlehttp/guzzle": "^6.3",
         "paragonie/certainty": "^1|^2",
-        "divineomega/do-file-cache-psr-6": "^2.0"
+        "divineomega/do-file-cache-psr-6": "^2.0",
+        "psr/cache": "^1.0"
     }
 }

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\ConnectException;
 use ParagonIE\Certainty\Bundle;
 use ParagonIE\Certainty\Fetch;
 use ParagonIE\Certainty\RemoteFetch;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class PasswordExposedChecker
@@ -23,7 +24,16 @@ class PasswordExposedChecker
 
     const CACHE_EXPIRY_SECONDS = 60 * 60 * 24 * 30;
 
-    public function __construct(Client $client = null, CacheItemPool $cache = null, Bundle $bundle = null)
+    /**
+     * PasswordExposedChecker constructor.
+     *
+     * @param Client|null $client
+     * @param CacheItemPoolInterface|null $cache
+     * @param Bundle|null $bundle
+     * @throws \ParagonIE\Certainty\Exception\CertaintyException
+     * @throws \SodiumException
+     */
+    public function __construct(Client $client = null, CacheItemPoolInterface $cache = null, Bundle $bundle = null)
     {
         if (!$client) {
             $client = new Client([
@@ -48,7 +58,11 @@ class PasswordExposedChecker
     }
 
     /**
+     * Get secure bundle from Certainty.
+     *
      * @return Bundle
+     * @throws \ParagonIE\Certainty\Exception\CertaintyException
+     * @throws \SodiumException
      */
     private function getBundleFromCertainty()
     {
@@ -75,9 +89,13 @@ class PasswordExposedChecker
     }
 
     /**
+     * Check if password has been exposed.
+     *
      * @param string $password
      *
      * @return string (see PasswordStatus)
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Psr\Cache\InvalidArgumentException
      */
     public function passwordExposed($password)
     {
@@ -85,9 +103,13 @@ class PasswordExposedChecker
     }
 
     /**
+     * Check if password has been exposed (using SHA1 hash).
+     *
      * @param string $hash Hexadecimal SHA-1 hash of the password
      *
      * @return string (see PasswordStatus)
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Psr\Cache\InvalidArgumentException
      */
     public function passwordExposedByHash($hash)
     {
@@ -122,9 +144,12 @@ class PasswordExposedChecker
     }
 
     /**
+     * Perform request to HIBP Passwords API.
+     *
      * @param string $hash
      *
      * @return \Psr\Http\Message\ResponseInterface
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     private function makeRequest($hash)
     {
@@ -140,10 +165,12 @@ class PasswordExposedChecker
     }
 
     /**
+     * Convert response body to PasswordStatus constant.
+     *
      * @param string $hash
      * @param string $responseBody
      *
-     * @return string
+     * @return string (see PasswordStatus)
      */
     private function getPasswordStatus($hash, $responseBody)
     {

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -27,9 +27,10 @@ class PasswordExposedChecker
     /**
      * PasswordExposedChecker constructor.
      *
-     * @param Client|null $client
+     * @param Client|null                 $client
      * @param CacheItemPoolInterface|null $cache
-     * @param Bundle|null $bundle
+     * @param Bundle|null                 $bundle
+     *
      * @throws \ParagonIE\Certainty\Exception\CertaintyException
      * @throws \SodiumException
      */
@@ -60,9 +61,10 @@ class PasswordExposedChecker
     /**
      * Get secure bundle from Certainty.
      *
-     * @return Bundle
      * @throws \ParagonIE\Certainty\Exception\CertaintyException
      * @throws \SodiumException
+     *
+     * @return Bundle
      */
     private function getBundleFromCertainty()
     {
@@ -93,9 +95,10 @@ class PasswordExposedChecker
      *
      * @param string $password
      *
-     * @return string (see PasswordStatus)
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Psr\Cache\InvalidArgumentException
+     *
+     * @return string (see PasswordStatus)
      */
     public function passwordExposed($password)
     {
@@ -107,9 +110,10 @@ class PasswordExposedChecker
      *
      * @param string $hash Hexadecimal SHA-1 hash of the password
      *
-     * @return string (see PasswordStatus)
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Psr\Cache\InvalidArgumentException
+     *
+     * @return string (see PasswordStatus)
      */
     public function passwordExposedByHash($hash)
     {
@@ -148,8 +152,9 @@ class PasswordExposedChecker
      *
      * @param string $hash
      *
-     * @return \Psr\Http\Message\ResponseInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @return \Psr\Http\Message\ResponseInterface
      */
     private function makeRequest($hash)
     {

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -134,11 +134,11 @@ class PasswordExposedChecker
 
             /** @var string $responseBody */
             $responseBody = (string) $response->getBody();
-        }
 
-        $cacheItem->set($responseBody);
-        $cacheItem->expiresAfter(self::CACHE_EXPIRY_SECONDS);
-        $this->cache->save($cacheItem);
+            $cacheItem->set($responseBody);
+            $cacheItem->expiresAfter(self::CACHE_EXPIRY_SECONDS);
+            $this->cache->save($cacheItem);
+        }
 
         return $this->getPasswordStatus($hash, $responseBody);
     }

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -19,7 +19,7 @@ class PasswordExposedChecker
     /** @var Client $client */
     private $client;
 
-    /** @var CacheItemPool $cache */
+    /** @var CacheItemPoolInterface $cache */
     private $cache;
 
     const CACHE_EXPIRY_SECONDS = 60 * 60 * 24 * 30;


### PR DESCRIPTION
This PR allows developers to make use of any PSR 6 compliance cache.

It also improves the existing caching, to prevent unnecessary re-caching.