### PR TITLE
Changed some return types

### DIFF
--- a/src/AbstractPasswordExposedChecker.php
+++ b/src/AbstractPasswordExposedChecker.php
@@ -154,9 +154,9 @@ abstract class AbstractPasswordExposedChecker implements PasswordExposedCheckerI
     }
 
     /**
-     * @return ClientInterface
+     * @return ClientInterface|\GuzzleHttp\ClientInterface
      */
-    abstract protected function getClient(): ClientInterface;
+    abstract protected function getClient();
 
     /**
      * @return CacheItemPoolInterface

--- a/src/AbstractPasswordExposedChecker.php
+++ b/src/AbstractPasswordExposedChecker.php
@@ -4,9 +4,9 @@ namespace DivineOmega\PasswordExposed;
 
 use DivineOmega\PasswordExposed\Enums\PasswordStatus;
 use DivineOmega\PasswordExposed\Interfaces\PasswordExposedCheckerInterface;
+use Http\Client\HttpClient;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Client\ClientExceptionInterface;
-use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriFactoryInterface;
@@ -154,9 +154,9 @@ abstract class AbstractPasswordExposedChecker implements PasswordExposedCheckerI
     }
 
     /**
-     * @return ClientInterface|\GuzzleHttp\ClientInterface
+     * @return \Http\Client\HttpClient
      */
-    abstract protected function getClient();
+    abstract protected function getClient(): HttpClient;
 
     /**
      * @return CacheItemPoolInterface

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -70,9 +70,9 @@ class PasswordExposedChecker extends AbstractPasswordExposedChecker
     }
 
     /**
-     * @return ClientInterface
+     * @return ClientInterface|\GuzzleHttp\ClientInterface
      */
-    protected function createClient(): ClientInterface
+    protected function createClient()
     {
         $options = [
             'timeout' => 3,

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -60,7 +60,7 @@ class PasswordExposedChecker extends AbstractPasswordExposedChecker
     /**
      * {@inheritdoc}
      */
-    protected function getClient(): ClientInterface
+    protected function getClient()
     {
         if ($this->client === null) {
             $this->client = $this->createClient();

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -4,12 +4,12 @@ namespace DivineOmega\PasswordExposed;
 
 use DivineOmega\DOFileCachePSR6\CacheItemPool;
 use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
+use Http\Client\HttpClient;
 use Http\Discovery\Psr17FactoryDiscovery;
 use ParagonIE\Certainty\Bundle;
 use ParagonIE\Certainty\Fetch;
 use ParagonIE\Certainty\RemoteFetch;
 use Psr\Cache\CacheItemPoolInterface;
-use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
 
@@ -18,7 +18,7 @@ use Psr\Http\Message\UriFactoryInterface;
  */
 class PasswordExposedChecker extends AbstractPasswordExposedChecker
 {
-    /** @var ClientInterface|null */
+    /** @var HttpClient|null */
     protected $client;
 
     /** @var CacheItemPoolInterface|null */
@@ -37,14 +37,14 @@ class PasswordExposedChecker extends AbstractPasswordExposedChecker
     protected $uriFactory;
 
     /**
-     * @param ClientInterface|null         $client
+     * @param HttpClient|null              $client
      * @param CacheItemPoolInterface|null  $cache
      * @param int|null                     $cacheLifeTime
      * @param RequestFactoryInterface|null $requestFactory
      * @param UriFactoryInterface|null     $uriFactory
      */
     public function __construct(
-        ?ClientInterface $client = null,
+        ?HttpClient $client = null,
         ?CacheItemPoolInterface $cache = null,
         ?int $cacheLifeTime = null,
         ?RequestFactoryInterface $requestFactory = null,
@@ -60,7 +60,7 @@ class PasswordExposedChecker extends AbstractPasswordExposedChecker
     /**
      * {@inheritdoc}
      */
-    protected function getClient()
+    protected function getClient(): HttpClient
     {
         if ($this->client === null) {
             $this->client = $this->createClient();
@@ -70,9 +70,9 @@ class PasswordExposedChecker extends AbstractPasswordExposedChecker
     }
 
     /**
-     * @return ClientInterface|\GuzzleHttp\ClientInterface
+     * @return HttpClient
      */
-    protected function createClient()
+    protected function createClient(): HttpClient
     {
         $options = [
             'timeout' => 3,


### PR DESCRIPTION
`\Http\Client\HttpClient` doesn't implement `\Psr\Http\Client\ClientInterface` in `php-http/guzzle6-adapter` `^1.1` which makes the package incompatible with recent versions of `laravel/framework`