### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
-dist: trusty
 php:
-  - '7.1.18'
+  - '7.1.33'
   - '7.2'
   - '7.3'
   - nightly

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "divineomega/psr-18-guzzle-adapter": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^7.0||^8.0",
         "fzaninotto/faker": "^1.7",
         "vimeo/psalm": "^1",
         "kriswallsmith/buzz": "^1.0",

--- a/tests/Unit/CustomInjectionsTest.php
+++ b/tests/Unit/CustomInjectionsTest.php
@@ -21,8 +21,8 @@ class CustomInjectionsTest extends TestCase
 
         $passwordExposedChecker = new PasswordExposedChecker(null, $cache);
 
-        $this->assertEquals(true, $passwordExposedChecker->isExposed('hunter2'));
-        $this->assertEquals(false, $passwordExposedChecker->isExposed($this->getPasswordHashUnlikelyToBeExposed()));
+        $this->assertTrue($passwordExposedChecker->isExposed('hunter2'));
+        $this->assertFalse($passwordExposedChecker->isExposed($this->getPasswordHashUnlikelyToBeExposed()));
     }
 
     public function testCustomLibrary()

--- a/tests/Unit/PasswordExposedByHashTest.php
+++ b/tests/Unit/PasswordExposedByHashTest.php
@@ -13,7 +13,7 @@ class PasswordExposedByHashTest extends TestCase
     /** @var PasswordExposedChecker */
     private $checker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $cache = new CacheItemPool();
         $cache->changeConfig(
@@ -51,8 +51,8 @@ class PasswordExposedByHashTest extends TestCase
     {
         $this->assertEquals($this->checker->passwordExposedByHash($hash), PasswordStatus::EXPOSED);
         $this->assertEquals(password_exposed_by_hash($hash), PasswordStatus::EXPOSED);
-        $this->assertEquals($this->checker->isExposedByHash($hash), true);
-        $this->assertEquals(password_is_exposed_by_hash($hash), true);
+        $this->assertTrue($this->checker->isExposedByHash($hash));
+        $this->assertTrue(password_is_exposed_by_hash($hash));
     }
 
     public function testNotExposedPasswords()

--- a/tests/Unit/PasswordExposedTest.php
+++ b/tests/Unit/PasswordExposedTest.php
@@ -13,7 +13,7 @@ class PasswordExposedTest extends TestCase
     /** @var PasswordExposedChecker */
     private $checker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $cache = new CacheItemPool();
         $cache->changeConfig(
@@ -46,8 +46,8 @@ class PasswordExposedTest extends TestCase
     {
         $this->assertEquals($this->checker->passwordExposed($password), PasswordStatus::EXPOSED);
         $this->assertEquals(password_exposed($password), PasswordStatus::EXPOSED);
-        $this->assertEquals($this->checker->isExposed($password), true);
-        $this->assertEquals(password_is_exposed($password), true);
+        $this->assertTrue($this->checker->isExposed($password));
+        $this->assertTrue(password_is_exposed($password));
     }
 
     public function testNotExposedPasswords()


### PR DESCRIPTION
# Changed log
- The `php-7.1.33` version is latest stable `php-7.1` version now.
- Remove `trusty` dist and these `php-7.x` versions are enabled on `xenial` dist by default.
- Upgrade the `PHPUnit` version to be `^7.0||^8.0`.
To be compatible with `PHPUnit 7.x` and `PHPUnit 8.x` versions, it should add `:void` to be compatible with `PHPUnit\Framework\TestCase::setUp` method.
- Using the `assertTrue` and `assertFalse` assertions to assert expected value is `true` or `false`.