### PR TITLE
Support PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
   allow_failures:
     -   php: nightly
 install:
-  - composer self-update --1
-  - composer --version
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer require --dev vimeo/psalm:1.1.9; else composer require --dev vimeo/psalm:1.1.8; fi
   - ./vendor/bin/psalm
 after_script:
   - php vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   allow_failures:
     -   php: nightly
 install:
-  - php composer.phar self-update --1 --snapshot
+  - composer self-update --1 --snapshot
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   allow_failures:
     -   php: nightly
 install:
+  - php composer.phar self-update --1 --snapshot
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   allow_failures:
     -   php: nightly
 install:
-  - composer self-update --1 --snapshot
+  - composer self-update --1
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ php:
   - '7.1.33'
   - '7.2'
   - '7.3'
+  - '7.4'
+  - '8.0'
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer require --dev psalm; else; composer require --dev psalm@1.1.8; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer require --dev psalm; else composer require --dev psalm@1.1.8; fi
   - ./vendor/bin/psalm
 after_script:
   - php vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer require --dev vimeo/psalm@1.x.x; else composer require --dev vimeo/psalm@1.1.8; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer require --dev vimeo/psalm:1.1.9; else composer require --dev vimeo/psalm:1.1.8; fi
   - ./vendor/bin/psalm
 after_script:
   - php vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer require --dev psalm; else; composer require --dev psalm@1.1.8; fi
   - ./vendor/bin/psalm
 after_script:
   - php vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer require --dev psalm; else composer require --dev psalm@1.1.8; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "8.0" ]]; then composer require --dev vimeo/psalm@1.x.x; else composer require --dev vimeo/psalm@1.1.8; fi
   - ./vendor/bin/psalm
 after_script:
   - php vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     -   php: nightly
 install:
   - composer self-update --1
+  - composer --version
   - composer install
 script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0||^8.0",
         "fzaninotto/faker": "^1.7",
-        "vimeo/psalm": "^1",
+        "vimeo/psalm": "1.1.8",
         "kriswallsmith/buzz": "^1.0",
         "symfony/cache": "^4.2.12",
         "php-coveralls/php-coveralls": "^2.1"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0||^8.0",
         "fzaninotto/faker": "^1.7",
+        "vimeo/psalm": "^4",
         "kriswallsmith/buzz": "^1.0",
         "symfony/cache": "^4.2.12",
         "php-coveralls/php-coveralls": "^2.1"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0||^8.0",
         "fzaninotto/faker": "^1.7",
-        "vimeo/psalm": "1.1.8",
         "kriswallsmith/buzz": "^1.0",
         "symfony/cache": "^4.2.12",
         "php-coveralls/php-coveralls": "^2.1"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1||^8.0",
         "psr/http-client": "^1.0",
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",

--- a/src/PasswordExposedChecker.php
+++ b/src/PasswordExposedChecker.php
@@ -166,7 +166,7 @@ class PasswordExposedChecker extends AbstractPasswordExposedChecker
      */
     protected function createUriFactory(): UriFactoryInterface
     {
-        return Psr17FactoryDiscovery::findUrlFactory();
+        return Psr17FactoryDiscovery::findUriFactory();
     }
 
     /**


### PR DESCRIPTION
Adds support for PHP 8.  The following changes were necessary to get the builds running again:

- Composer 2 is installed by default, this isn't compatible with some of your dependencies so I've instructed it to roll back to Composer 1.
- Psalm 1.1.9 includes syntax which isn't compatible with older PHP versions, while 1.1.8 isn't able to install on PHP 8.  I've split the difference by making it install different versions depending upon the PHP version.
- There was a use of a deprecated function which meant that the Psalm check was failing.
- Also updates https://github.com/DivineOmega/psr-18-guzzle-adapter to allow 8.0 support.