### PR TITLE
Allow modern PSR cache adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This PHP package provides a `password_exposed` helper function, that uses the haveibeenpwned.com API to check if a password has been exposed in a data breach.
 
+It supports PHP 7.1 through current releases. On PHP 8 it can use the PSR-6 v4 cache adapter required by modern frameworks, while PHP 7 installations continue to resolve the compatible v3 adapter.
+
 <p align="center">
     <img src="assets/images/password-exposed.png">
 </p>

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-http/discovery": "^1.6",
         "nyholm/psr7": "^1.0",
         "paragonie/certainty": "^2.4",
-        "jord-jd/do-file-cache-psr-6": "^3.0",
+        "jord-jd/do-file-cache-psr-6": "^3.0 || ^4.0",
         "jord-jd/psr-18-guzzle-adapter": "^3.0"
     },
     "require-dev": {
@@ -57,7 +57,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0-dev"
+            "dev-master": "5.1-dev"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
- Allow the current PSR-6 cache adapter on PHP 8 so modern Symfony applications can resolve PSR Cache 2 or 3.
- Preserve the v3 cache adapter path for PHP 7.1 users.
- Document the conditional compatibility behavior.
